### PR TITLE
Annotating the fanout queue instead of the internal queues

### DIFF
--- a/docker_agent_workflow.cwl
+++ b/docker_agent_workflow.cwl
@@ -72,8 +72,6 @@ steps:
     out:
       - id: docker_repository
       - id: docker_digest
-      #- id: entityid
-      # SH
       - id: entity_id
       - id: results
 
@@ -145,7 +143,7 @@ steps:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/annotate_submission.cwl
     in:
       - id: submissionid
-        source: "#submissionId"
+        source: "#get_submissionid/submissionId"
       - id: annotation_values
         source: "#upload_results/results"
       - id: to_public
@@ -209,7 +207,7 @@ steps:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v2.1/annotate_submission.cwl
     in:
       - id: submissionid
-        source: "#submissionId"
+        source: "#get_submissionid/submissionId"
       - id: annotation_values
         source: "#validate_and_score/results"
       - id: to_public


### PR DESCRIPTION
This is incomplete, as there are different annotations we could add based on where we are on in the internal queue workflow.