### PR TITLE
Add in RECEIVED state check

### DIFF
--- a/get_backend_queue.cwl
+++ b/get_backend_queue.cwl
@@ -55,8 +55,9 @@ requirements:
           while not free_queues:
             for queue in args.queues:
               # list submissions that are evaluation in progress
+              received_submissions = list(syn.getSubmissionBundles(queue, status="RECEIVED"))
               evaluating_submissions = list(syn.getSubmissionBundles(queue, status="EVALUATION_IN_PROGRESS"))
-              if not evaluating_submissions:
+              if not evaluating_submissions and not received_submissions:
                 free_queues.append(queue)
             if not free_queues:
               time.sleep(30)


### PR DESCRIPTION
Even with this, you would still need to see in your .env on every machine

`MAX_CONCURRENT_WORKFLOW=1`
#34 